### PR TITLE
Optimize inference and training configuration

### DIFF
--- a/bot_ecosystem/ai_system.py
+++ b/bot_ecosystem/ai_system.py
@@ -1,26 +1,20 @@
+import os
 from transformers import AutoModelForSequenceClassification, AutoTokenizer
 import torch
-def predict_sentiment(model_path,text):
-    model = AutoModelForSequenceClassification.from_pretrained(model_path)
-    tokenizer = AutoTokenizer.from_pretrained(model_path)
-    # memilih device yang tepat
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    model.to(device)
-    # Tokenisasi teks
-    inputs = tokenizer(text, padding=True, truncation=True, max_length=128, return_tensors="pt")
-    inputs = {key: value.to(device) for key, value in inputs.items()}
 
-    # Mendapatkan prediksi dari model
+_MODEL_PATH = os.getenv("MODEL_PATH", "model")
+_DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+_TOKENIZER = AutoTokenizer.from_pretrained(_MODEL_PATH)
+_MODEL = AutoModelForSequenceClassification.from_pretrained(_MODEL_PATH)
+_MODEL.to(_DEVICE)
+_MODEL.eval()
+_LABEL_DICT = {1: "positif", 0: "netral", 2: "negatif"}
+
+def predict_sentiment(text: str) -> str:
+    inputs = _TOKENIZER(text, padding=True, truncation=True, max_length=128, return_tensors="pt")
+    inputs = {key: value.to(_DEVICE) for key, value in inputs.items()}
     with torch.no_grad():
-        logits = model(**inputs).logits
-
-    # Mengubah logits ke probabilitas
+        logits = _MODEL(**inputs).logits
     probabilities = torch.nn.functional.softmax(logits, dim=-1)
-
-    # Mengambil kelas dengan probabilitas tertinggi
     predicted_class = torch.argmax(probabilities, dim=-1).item()
-    
-    # Reverse integer menjadi value
-    label_dict = {1:'positif', 0:'netral', 2:'negatif'}
-    predicted_class = label_dict[predicted_class]
-    return predicted_class
+    return _LABEL_DICT.get(predicted_class, "tidak diketahui")

--- a/bot_ecosystem/bot_telegram.py
+++ b/bot_ecosystem/bot_telegram.py
@@ -1,38 +1,40 @@
 from telethon import TelegramClient, events
 from dotenv import load_dotenv
 import os
-from bot_ecosystem.ai_system import *
+
+from bot_ecosystem.ai_system import predict_sentiment
 
 # Load environment variables
 load_dotenv()
 api_id = os.getenv('API_ID')
 api_hash = os.getenv('API_HASH')
 bot_token = os.getenv('BOT_TOKEN')
-model_path = os.getenv('MODEL_PATH')
 
 # Create the client and connect
 bot = TelegramClient('bot', api_id, api_hash).start(bot_token=bot_token)
 
 @bot.on(events.NewMessage(pattern='/start'))
 async def start(event):
-    '''send message when the command /start is issued.'''
+    """send message when the command /start is issued."""
     await event.reply('Halo, saya alpher fungsi saya untuk')
 
 @bot.on(events.NewMessage(pattern='/sentimen'))
-async def echo(event):
-    '''send message when the command /sentimen is issued.'''
+async def sentimen(event):
+    """send message when the command /sentimen is issued."""
     data = event.text.split()
     data.pop(0)
     data = ' '.join(data)
-    respone = predict_sentiment('model',data)
-    respone = f'sentimennya adalah {respone}'
-    await event.respond(respone)
+    response = predict_sentiment(data)
+    response = f'sentimennya adalah {response}'
+    await event.respond(response)
+
 @bot.on(events.NewMessage(pattern='/echo'))
 async def echo(event):
-    '''send message when the command /echo is issued.'''
+    """send message when the command /echo is issued."""
     print(event.date, event.peer_id)
     await event.respond(event.text)
+
 def run():
-    '''start the bot'''
+    """start the bot"""
     print("alpher connected")
     bot.run_until_disconnected()

--- a/machine_training.ipynb
+++ b/machine_training.ipynb
@@ -145,7 +145,8 @@
     "from sklearn.model_selection import train_test_split\n",
     "from sklearn.metrics import precision_recall_fscore_support, accuracy_score\n",
     "from dotenv import load_dotenv\n",
-    "import os"
+    "import os\n",
+    "import torch\n"
    ]
   },
   {
@@ -313,8 +314,10 @@
     "train_dataset = Dataset.from_pandas(pd.DataFrame({'text': train_texts, 'labels': train_labels}))\n",
     "val_dataset = Dataset.from_pandas(pd.DataFrame({'text': val_texts, 'labels': val_labels}))\n",
     "\n",
-    "train_dataset = train_dataset.map(tokenize_function, batched=True)\n",
-    "val_dataset = val_dataset.map(tokenize_function, batched=True)\n",
+    "num_proc = os.cpu_count() or 1\n",
+    "\n",
+    "train_dataset = train_dataset.map(tokenize_function, batched=True, num_proc=num_proc)\n",
+    "val_dataset = val_dataset.map(tokenize_function, batched=True, num_proc=num_proc)\n",
     "\n",
     "train_dataset.set_format('torch', columns=['input_ids', 'attention_mask', 'labels'])\n",
     "val_dataset.set_format('torch', columns=['input_ids', 'attention_mask', 'labels'])"
@@ -384,12 +387,15 @@
     "training_args = TrainingArguments(\n",
     "    output_dir='./results',\n",
     "    num_train_epochs=3,\n",
-    "    per_device_train_batch_size=8,\n",
-    "    warmup_steps=500,\n",
+    "    per_device_train_batch_size=16,\n",
+    "    per_device_eval_batch_size=16,\n",
+    "    gradient_accumulation_steps=2,\n",
+    "    warmup_steps=0,\n",
     "    weight_decay=0.01,\n",
     "    logging_dir='./logs',\n",
     "    logging_steps=10,\n",
-    "    evaluation_strategy=\"epoch\"\n",
+    "    evaluation_strategy=\"epoch\",\n",
+    "    fp16=torch.cuda.is_available(),\n",
     ")\n",
     "\n",
     "# Inisialisasi Trainer\n",


### PR DESCRIPTION
## Summary
- cache the tokenizer and model in `ai_system` so inference reuses a single loaded instance and stays on the right device
- update the Telegram bot handler to use the cached predictor and tidy handler naming
- tune the training notebook to import torch, parallelise tokenisation, and enable larger mixed-precision batches

## Testing
- python -m compileall bot_ecosystem

------
https://chatgpt.com/codex/tasks/task_e_68ca35535bd483229408e7396407f315